### PR TITLE
Focus Camera

### DIFF
--- a/Assets/Assets/Scripts/Bacterium.cs
+++ b/Assets/Assets/Scripts/Bacterium.cs
@@ -223,7 +223,7 @@ public class Bacterium : MonoBehaviour
             attackCooldown += GameManager._instance.attackCooldown;
 
             //Deals damage, steals energy
-            float damage = Mathf.Max(0f,genome.AttackSkill.Effect);
+            float damage = Mathf.Max(0f, genome.AttackSkill.Effect);
             damage = Mathf.Min(damage, other.energy);
             Eat(damage);
             other.TakeDamage(damage);
@@ -288,7 +288,7 @@ public class Bacterium : MonoBehaviour
         energy *= 0.5f;
         Genome childGenome = new Genome(genome);
         childGenome.Mutate(0.5f);
-        Bacterium childBacterium = GameManager._instance.SpawnBacterium(rigidBody.transform.position,childGenome);
+        Bacterium childBacterium = GameManager._instance.SpawnBacterium(rigidBody.transform.position, childGenome);
         childBacterium.energy = energy;
     }
     public void SpendEnergy()
@@ -305,7 +305,7 @@ public class Bacterium : MonoBehaviour
     {
         for (int i = 0; i < targets.Length; i++)
         {
-            switch(i)
+            switch (i)
             {
                 case 0:
                     Gizmos.color = Color.green;

--- a/Assets/Assets/Scripts/CameraController.cs
+++ b/Assets/Assets/Scripts/CameraController.cs
@@ -4,7 +4,9 @@ using UnityEngine;
 
 public class CameraController : MonoBehaviour
 {
-    Camera cameraObj;
+    Camera cam;
+
+    GameObject focusObj;
 
     [SerializeField]
     //bool isPanning;
@@ -38,15 +40,21 @@ public class CameraController : MonoBehaviour
 
     private void Awake()
     {
-        cameraObj = gameObject.GetComponent<Camera>();
+        cam = gameObject.GetComponent<Camera>();
     }
 
     void Update()
     {
         Vector3 pos = transform.position;
 
+        if (focusObj != null)
+        {
+            pos.x = focusObj.transform.position.x;
+            pos.y = focusObj.transform.position.y;
+        }
+
         //Pan
-        if (!isDragging)
+        if (!isDragging && focusObj == null)
         {
             Vector3 screenCenter = new Vector3(Screen.width / 2, Screen.height / 2, 0);
             moveDirection = Input.mousePosition - screenCenter;
@@ -72,26 +80,37 @@ public class CameraController : MonoBehaviour
 
         //Drag
         if (Input.GetMouseButtonDown(2))
-            dragOrigin = cameraObj.ScreenToWorldPoint(Input.mousePosition);
+            dragOrigin = cam.ScreenToWorldPoint(Input.mousePosition);
         if (Input.GetMouseButton(2))
         {
             isDragging = true;
 
-            Vector3 dragMove = cameraObj.ScreenToWorldPoint(Input.mousePosition) - dragOrigin;
+            Vector3 dragMove = cam.ScreenToWorldPoint(Input.mousePosition) - dragOrigin;
             pos -= dragMove * dragSpeed;
+
+            StopFocusCamera();
         }
         else
             isDragging = false;
 
         //Scroll
-        cameraObj.orthographicSize -= Input.GetAxis("Mouse ScrollWheel") * scrollSpeed * Time.deltaTime;
-        cameraObj.orthographicSize = Mathf.Clamp(cameraObj.orthographicSize, minCameraSize, maxCameraSize);
+        cam.orthographicSize -= Input.GetAxis("Mouse ScrollWheel") * scrollSpeed * Time.deltaTime;
+        cam.orthographicSize = Mathf.Clamp(cam.orthographicSize, minCameraSize, maxCameraSize);
 
         //Borders
-        float cameraSize = cameraObj.orthographicSize;
+        float cameraSize = cam.orthographicSize;
         pos.x = Mathf.Clamp(pos.x, -(GameManager._instance.gameArea.x - cameraSize), GameManager._instance.gameArea.x - cameraSize);
         pos.y = Mathf.Clamp(pos.y, -(GameManager._instance.gameArea.y - cameraSize), GameManager._instance.gameArea.y - cameraSize);
 
         transform.position = pos;
+    }
+
+    public void FocusCameraOn(GameObject obj)
+    {
+        focusObj = obj;
+    }
+    public void StopFocusCamera()
+    {
+        focusObj = null;
     }
 }

--- a/Assets/Assets/Scripts/GameManager.cs
+++ b/Assets/Assets/Scripts/GameManager.cs
@@ -42,6 +42,7 @@ public class GameManager : MonoBehaviour
 
     private int SpawnFoodPerTick => Mathf.RoundToInt(Mathf.Max(StartNumberOfFood / 15, 1) * spawnFoodTickDelay);
     public int NumberOfNeurons => maxObject * maxObject * 4;
+    public CameraController camCtrl;
 
     void Start()
     {
@@ -51,6 +52,8 @@ public class GameManager : MonoBehaviour
             Destroy(gameObject);
 
         DontDestroyOnLoad(gameObject);
+
+        camCtrl = gameObject.GetComponent<CameraController>();
 
         foodHolder = new GameObject("Food Holder").transform;
         bacteriumHolder = new GameObject("Bacterium Holder").transform;

--- a/Assets/Assets/Scripts/UI/Tooltip.cs
+++ b/Assets/Assets/Scripts/UI/Tooltip.cs
@@ -5,24 +5,12 @@ public class Tooltip : MonoBehaviour
     [TextArea(10, 10)]
     public string message;
 
-    public bool onClick = false;
-    public bool onMouseOver = false;
-
     private void OnMouseDown()
     {
-        if (Input.GetMouseButtonDown(0) && onClick)
+        if (Input.GetMouseButtonDown(0))
         {
             TooltipManager._instance.SetActiveTooltip(this);
+            GameManager._instance.camCtrl.FocusCameraOn(gameObject);
         }
-    }
-    private void OnMouseEnter()
-    {
-        if(onMouseOver)
-            TooltipManager._instance.SetActiveTooltip(this);
-    }
-    private void OnMouseExit()
-    {
-        if (onMouseOver)
-            TooltipManager._instance.ClearActiveTooltip();
     }
 }

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -674,7 +674,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gameArea: {x: 120, y: 120}
-  StartNumberOfFood: 3000
+  StartNumberOfFood: 1500
   StartNumberOfBacteria: 400
   mutationBeforeNewID: 10
   energyPerSecondLoss: 0.25
@@ -688,6 +688,8 @@ MonoBehaviour:
   recentGenomeID: 0
   recentBacteriumID: 0
   AITickDelay: 0.1
+  maxObject: 5
+  camCtrl: {fileID: 0}
 --- !u!114 &1148454233
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Changelog:
- Got rid of leftovers in the `Tooltip`.
- Right-clicking bacteria focus the camera on them. Dragging disables it.
- Set less food on the map because it's laggy when there is a lot of bacteria.